### PR TITLE
fix: dependabot noise around ruff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "ruff"  # too much noise
     allow:
       - dependency-name: "*"
         dependency-type: all

--- a/poetry.lock
+++ b/poetry.lock
@@ -384,4 +384,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "85f0cbe5f21ae4183c29d01e2673cf58a9d3e94da96543c2e3f13c6236c6b143"
+content-hash = "d5704549ee88e3bc7ee1d2a46a3be49c933cfbd34761c1a906c027513f212102"

--- a/poetry.lock
+++ b/poetry.lock
@@ -335,27 +335,28 @@ pytest = "*"
 
 [[package]]
 name = "ruff"
-version = "0.0.223"
-description = "An extremely fast Python linter, written in Rust."
+version = "0.1.13"
+description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.0.223-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:7d4f5ba5e4779dcc8ca7e61f96ad867792c205bf961fc486890cd5fd24b73884"},
-    {file = "ruff-0.0.223-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:2204aba39fe76bf4efd88290554899f1d0c0e3fd8b69fb80819abf6738fd889e"},
-    {file = "ruff-0.0.223-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1151008716230ae3086fc0754e6abf2dde013e8504b77a911a03e07386eda85e"},
-    {file = "ruff-0.0.223-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9613848d4ad72a79f185c3c78f8777e6d3e5f65bf15fbba97dabc01d17254014"},
-    {file = "ruff-0.0.223-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edbc88507f8417102d002f15bccf457340d3e2c3c304f77472ff39927a0769a2"},
-    {file = "ruff-0.0.223-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:6fe10bf4d0efa81360c6d32ffb41f242de1ef187a65c81021fe7947e0a84e7cd"},
-    {file = "ruff-0.0.223-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9656ba683f6627ca85257b4dc449ce76b68763c848172069811b222611d904c7"},
-    {file = "ruff-0.0.223-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ad3f84559be0f87788f11503a185f322360d45942c07a0461eda791dcfb3d83d"},
-    {file = "ruff-0.0.223-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc554613ad218a82929e05d31d2da6e4fa85b6f6c82a09c6de5c9f79159c02e5"},
-    {file = "ruff-0.0.223-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d115714dcf039ed6d75254f4e2023259ce5261330bd1ab2567f15f58680191b3"},
-    {file = "ruff-0.0.223-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e856dcce47b695bee20fdc3f2da3e29026642ca1b71dbc98723cb62c38294952"},
-    {file = "ruff-0.0.223-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cf64a6368eca3bb34aa4606425ed46c632cfd4197086ce6746efa6c5de188940"},
-    {file = "ruff-0.0.223-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:57a302273315fa1582ec262bd3ca0d057d21cd96359f2ba9fb582ef30f897a68"},
-    {file = "ruff-0.0.223-py3-none-win32.whl", hash = "sha256:25fe04755c3d68240c3320b3420dc0a4157c2c1952a063014c44d5c382bd8368"},
-    {file = "ruff-0.0.223-py3-none-win_amd64.whl", hash = "sha256:2bad5fcfcf374f76744e96661dd6f04e65d83d51c54507db9faf580a9cd93ec3"},
-    {file = "ruff-0.0.223.tar.gz", hash = "sha256:35359ee7fe710a19380e3eaba2fe45abe0a881057e0fe5a2ae7fbc29b6e8fca3"},
+    {file = "ruff-0.1.13-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:e3fd36e0d48aeac672aa850045e784673449ce619afc12823ea7868fcc41d8ba"},
+    {file = "ruff-0.1.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9fb6b3b86450d4ec6a6732f9f60c4406061b6851c4b29f944f8c9d91c3611c7a"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b13ba5d7156daaf3fd08b6b993360a96060500aca7e307d95ecbc5bb47a69296"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9ebb40442f7b531e136d334ef0851412410061e65d61ca8ce90d894a094feb22"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:226b517f42d59a543d6383cfe03cccf0091e3e0ed1b856c6824be03d2a75d3b6"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:5f0312ba1061e9b8c724e9a702d3c8621e3c6e6c2c9bd862550ab2951ac75c16"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2f59bcf5217c661254bd6bc42d65a6fd1a8b80c48763cb5c2293295babd945dd"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e6894b00495e00c27b6ba61af1fc666f17de6140345e5ef27dd6e08fb987259d"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a1600942485c6e66119da294c6294856b5c86fd6df591ce293e4a4cc8e72989"},
+    {file = "ruff-0.1.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ee3febce7863e231a467f90e681d3d89210b900d49ce88723ce052c8761be8c7"},
+    {file = "ruff-0.1.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dcaab50e278ff497ee4d1fe69b29ca0a9a47cd954bb17963628fa417933c6eb1"},
+    {file = "ruff-0.1.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f57de973de4edef3ad3044d6a50c02ad9fc2dff0d88587f25f1a48e3f72edf5e"},
+    {file = "ruff-0.1.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7a36fa90eb12208272a858475ec43ac811ac37e91ef868759770b71bdabe27b6"},
+    {file = "ruff-0.1.13-py3-none-win32.whl", hash = "sha256:a623349a505ff768dad6bd57087e2461be8db58305ebd5577bd0e98631f9ae69"},
+    {file = "ruff-0.1.13-py3-none-win_amd64.whl", hash = "sha256:f988746e3c3982bea7f824c8fa318ce7f538c4dfefec99cd09c8770bd33e6539"},
+    {file = "ruff-0.1.13-py3-none-win_arm64.whl", hash = "sha256:6bbbc3042075871ec17f28864808540a26f0f79a4478c357d3e3d2284e832998"},
+    {file = "ruff-0.1.13.tar.gz", hash = "sha256:e261f1baed6291f434ffb1d5c6bd8051d1c2a26958072d38dfbec39b3dda7352"},
 ]
 
 [[package]]
@@ -383,4 +384,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d5704549ee88e3bc7ee1d2a46a3be49c933cfbd34761c1a906c027513f212102"
+content-hash = "85f0cbe5f21ae4183c29d01e2673cf58a9d3e94da96543c2e3f13c6236c6b143"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ peewee = "^3.17.0"
 [tool.poetry.group.dev.dependencies]
 black = "*"
 mypy = "*"
-ruff = "*"
+ruff = "0.1.13" # avoid dependabot noise
 
 [tool.ruff]
 src = ["src", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ peewee = "^3.17.0"
 [tool.poetry.group.dev.dependencies]
 black = "*"
 mypy = "*"
-ruff = "0.1.13" # avoid dependabot noise
+ruff = "*"  # avoid dependabot noise
 
 [tool.ruff]
 src = ["src", "tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,6 @@ def refactor(string: str) -> str:
 
 pytest_plugins = [
     refactor(fixture)
-    for fixture in glob("tests/fixtures/**/*.py")
-    if "__" not in fixture  # noqa: PLR2004
+    for fixture in glob("tests/fixtures/**/*.py")  # noqa: PTH207
+    if "__" not in fixture
 ]

--- a/tests/fixtures/orm/peewee.py
+++ b/tests/fixtures/orm/peewee.py
@@ -1,4 +1,4 @@
-import os
+import os  # noqa: INP001
 
 import pytest
 from playhouse.db_url import connect

--- a/tests/fixtures/orm/psycopg2.py
+++ b/tests/fixtures/orm/psycopg2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations  # noqa: INP001
+
 import os
 from typing import Callable
 from urllib.parse import urlparse

--- a/tests/json_aggregator/test_json_aggregator.py
+++ b/tests/json_aggregator/test_json_aggregator.py
@@ -1,4 +1,4 @@
-import json
+import json  # noqa: INP001
 import pathlib
 
 
@@ -18,9 +18,9 @@ def test_export_json_data(  # noqa: ANN201
     columns, rows = psycopg2_query(psycopg2_cursor, sql, sql_params)
 
     json_filepath = tmp_path / "export.json"
-    with open(json_filepath, "w") as outfile:
+    with open(json_filepath, "w") as outfile:  # noqa: PTH123
         json.dump(rows[0][0], outfile)
-    with open(json_filepath) as infile:
+    with open(json_filepath) as infile:  # noqa: PTH123
         loaded_json = json.load(infile)
 
     assert columns == ["json_agg"]

--- a/tests/peewee/test_orm_peewee.py
+++ b/tests/peewee/test_orm_peewee.py
@@ -1,4 +1,4 @@
-import pathlib
+import pathlib  # noqa: INP001
 
 
 def test_peewee_create_table(peewee_db):  # noqa: ANN001, ANN201

--- a/tests/psycopg2/test_orm_psycopg2.py
+++ b/tests/psycopg2/test_orm_psycopg2.py
@@ -1,4 +1,4 @@
-import pathlib
+import pathlib  # noqa: INP001
 
 
 def test_psycopg2_cursor(psycopg2_cursor):  # noqa: ANN001, ANN201

--- a/tests/udemy_course/test_section01.py
+++ b/tests/udemy_course/test_section01.py
@@ -1,4 +1,4 @@
-import pathlib
+import pathlib  # noqa: INP001
 
 import pytest
 

--- a/tests/udemy_course/test_section02.py
+++ b/tests/udemy_course/test_section02.py
@@ -1,4 +1,4 @@
-import pathlib
+import pathlib  # noqa: INP001
 
 import pytest
 

--- a/tests/udemy_course/test_section03.py
+++ b/tests/udemy_course/test_section03.py
@@ -1,4 +1,4 @@
-import pathlib
+import pathlib  # noqa: INP001
 
 import pytest
 


### PR DESCRIPTION
- upgrade to latest ruff
- add no-qa comments where needed
- fix an easy linting problem (add an import)
- supress further dependabot updates of ruff